### PR TITLE
Fix safe area padding and enforce dark background

### DIFF
--- a/emdr/ContentView.swift
+++ b/emdr/ContentView.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct ContentView: View {
     @State private var pointsPerSecond: Float = 2500
@@ -18,6 +21,8 @@ struct ContentView: View {
     
     var body: some View {
         GeometryReader { geometry in
+            let safeArea = resolvedSafeAreaInsets(from: geometry)
+
             ZStack {
                 // Metal-backed moving dot
                 MetalView(
@@ -25,11 +30,13 @@ struct ContentView: View {
                     dotRadius: Float(dotDiameter / 2),
                     color: SIMD4<Float>(1, 1, 1, 1),
                     paused: paused,
+                    safeAreaInsets: safeArea,
                     onTripleTap: { handleReset() },
                     onTap: { paused.toggle() },
                     onPanChanged: { dy in handlePanChanged(dy) },
                     onPanEnded: { handlePanEnded() }
                 )
+                .ignoresSafeArea()
 
                 // HUD/Toast overlay only; no hit testing so gestures reach MetalView
                 Color.clear.allowsHitTesting(false)
@@ -46,7 +53,8 @@ struct ContentView: View {
                                 .background(Color.black.opacity(0.6), in: Capsule())
                             Spacer()
                         }
-                        .padding([.top, .leading], 12)
+                        .padding(.top, safeArea.top + 12)
+                        .padding(.leading, safeArea.leading + 12)
                         Spacer()
                     }
                     .transition(.opacity)
@@ -63,7 +71,7 @@ struct ContentView: View {
                             .background(Color.black.opacity(0.7), in: Capsule())
                         Spacer()
                     }
-                    .padding(.top, 60)
+                    .padding(.top, safeArea.top + 60)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 }
             }
@@ -74,6 +82,7 @@ struct ContentView: View {
                 lastWidth = newWidth
             }
         }
+        .background(Color.black.ignoresSafeArea())
     }
 
     // MARK: - Gesture handlers via MetalView
@@ -98,6 +107,26 @@ struct ContentView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             withAnimation(.easeOut(duration: 0.2)) { isSliding = false }
         }
+    }
+
+    private func resolvedSafeAreaInsets(from geometry: GeometryProxy) -> EdgeInsets {
+        #if canImport(UIKit)
+        let geometryInsets = geometry.safeAreaInsets
+        if geometryInsets.top == 0,
+           geometryInsets.leading == 0,
+           geometryInsets.bottom == 0,
+           geometryInsets.trailing == 0,
+           let windowScene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive }),
+           let window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first {
+            let insets = window.safeAreaInsets
+            return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
+        }
+        return geometryInsets
+        #else
+        return geometry.safeAreaInsets
+        #endif
     }
 }
 

--- a/emdr/MetalView.swift
+++ b/emdr/MetalView.swift
@@ -13,6 +13,7 @@ struct MetalView: UIViewRepresentable {
     var onTap: (() -> Void)? = nil
     var onPanChanged: ((CGFloat) -> Void)? = nil
     var onPanEnded: (() -> Void)? = nil
+    var safeAreaInsets: EdgeInsets = EdgeInsets()
 
     func makeUIView(context: Context) -> MTKView {
         let view = MTKView()
@@ -24,6 +25,7 @@ struct MetalView: UIViewRepresentable {
             renderer.setRadius(points: dotRadius)
             renderer.setColor(color)
             renderer.setPaused(paused)
+            updateSafeArea(on: renderer, using: view)
         }
 
         // Triple-finger tap recognizer
@@ -55,10 +57,20 @@ struct MetalView: UIViewRepresentable {
             renderer.setRadius(points: dotRadius)
             renderer.setColor(color)
             renderer.setPaused(paused)
+            updateSafeArea(on: renderer, using: uiView)
         }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(onTripleTap: onTripleTap, onTap: onTap, onPanChanged: onPanChanged, onPanEnded: onPanEnded) }
+
+    private func updateSafeArea(on renderer: MetalRenderer, using view: MTKView) {
+        let scale = view.window?.screen.scale ?? UIScreen.main.scale
+        let left = Float(safeAreaInsets.leading) * Float(scale)
+        let right = Float(safeAreaInsets.trailing) * Float(scale)
+        let top = Float(safeAreaInsets.top) * Float(scale)
+        let bottom = Float(safeAreaInsets.bottom) * Float(scale)
+        renderer.setSafeAreaInsets(left: left, right: right, top: top, bottom: bottom)
+    }
 
     final class Coordinator: NSObject {
         var renderer: MetalRenderer?
@@ -116,6 +128,7 @@ struct MetalView: NSViewRepresentable {
     var onTap: (() -> Void)? = nil
     var onPanChanged: ((CGFloat) -> Void)? = nil
     var onPanEnded: (() -> Void)? = nil
+    var safeAreaInsets: EdgeInsets = EdgeInsets()
 
     func makeNSView(context: Context) -> MTKView {
         let view = MTKView()
@@ -127,6 +140,7 @@ struct MetalView: NSViewRepresentable {
             renderer.setRadius(points: dotRadius)
             renderer.setColor(color)
             renderer.setPaused(paused)
+            updateSafeArea(on: renderer, using: view)
         }
 
         // Triple-click recognizer (macOS analogue to triple-finger tap)
@@ -152,10 +166,20 @@ struct MetalView: NSViewRepresentable {
             renderer.setRadius(points: dotRadius)
             renderer.setColor(color)
             renderer.setPaused(paused)
+            updateSafeArea(on: renderer, using: nsView)
         }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(onTripleTap: onTripleTap, onTap: onTap, onPanChanged: onPanChanged, onPanEnded: onPanEnded) }
+
+    private func updateSafeArea(on renderer: MetalRenderer, using view: MTKView) {
+        let scale = view.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
+        let left = Float(safeAreaInsets.leading) * Float(scale)
+        let right = Float(safeAreaInsets.trailing) * Float(scale)
+        let top = Float(safeAreaInsets.top) * Float(scale)
+        let bottom = Float(safeAreaInsets.bottom) * Float(scale)
+        renderer.setSafeAreaInsets(left: left, right: right, top: top, bottom: bottom)
+    }
 
     final class Coordinator: NSObject {
         var renderer: MetalRenderer?
@@ -212,6 +236,7 @@ struct MetalView: View {
     var onTap: (() -> Void)? = nil
     var onPanChanged: ((CGFloat) -> Void)? = nil
     var onPanEnded: (() -> Void)? = nil
+    var safeAreaInsets: EdgeInsets = EdgeInsets()
 
     var body: some View {
         Text("MetalView is not supported on this platform.")

--- a/emdr/Shaders.metal
+++ b/emdr/Shaders.metal
@@ -41,9 +41,13 @@ fragment float4 fragment_dot(VertexOut in [[stage_in]], constant Uniforms& u [[b
     float2 p = in.uv * u.resolution;
 
     // Horizontal center travels back and forth between radius and width - radius
-    float usableWidth = max(0.0, u.resolution.x - 2.0 * u.radius);
+    float usableWidth = max(0.0, u.resolution.x - u.safeInsets.x - u.safeInsets.y - 2.0 * u.radius);
     float traveled = pingpong(u.time * u.speed, usableWidth);
-    float2 center = float2(u.radius + traveled, u.resolution.y * 0.5);
+    float centerX = u.safeInsets.x + u.radius + traveled;
+
+    float usableHeight = max(0.0, u.resolution.y - u.safeInsets.z - u.safeInsets.w);
+    float centerY = u.safeInsets.z + usableHeight * 0.5;
+    float2 center = float2(centerX, centerY);
 
     float dist = distance(p, center) - u.radius;
     float alpha = smoothstep(1.0, 0.0, dist); // anti-aliased edge


### PR DESCRIPTION
## Summary
- resolve device safe area insets and pass them into the Metal renderer to shrink unnecessary horizontal padding on Dynamic Island devices
- update MetalView and shader logic to honor asymmetric safe areas while keeping the dot centered vertically
- enforce a black background that ignores safe areas so the app stays dark even in light mode

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5f338c2bc832097089aeda92542b1